### PR TITLE
Improve styling and markup for index and demo pages.

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -9,7 +9,7 @@
 		<link href="demo/images/shortcut.png" rel="shortcut icon" type="image/x-icon" />
 		
 		<link rel="stylesheet" type="text/css" href="demo/css/reset.css" />
-		<link href='http://fonts.googleapis.com/css?family=Days+One|Righteous' rel='stylesheet' type='text/css'>
+		<link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Josefin+Sans:600" />
 		<link rel="stylesheet" type="text/css" href="demo/highlight/styles/vs.css" />
 		<link rel="stylesheet" type="text/css" href="demo/css/global.css"/>
 		<link rel="stylesheet" type="text/css" href="demo/css/demo.css"/>
@@ -41,22 +41,32 @@
 
 <body>
 
-<header>
-	<h1 id="logo">&lt;<span>x</span>&gt;</h1>
+<header class="container">
+	<h1 id="logo">X-Tag <code>&lt;X&gt;</code></h1>
+	
 	<nav id="global_menu">
-		<a href="#menu">
-			<div>&#9552;</div><br /><div>&#9552;</div>
-			<nav id="global_nav">
-				<a href="#structural">Structural Elements</a>
-				<a href="#media">Media Elements</a>
-				<a href="#input">Input Elements</a>
-				<a href="#navigation">Navigation Elements</a>
-			</nav>
-		</a>
+		<ul>
+			<li>
+				<a href="#structural">Structural</a>
+			</li>
+			<li>
+				<a href="#media">Media</a>
+			</li>
+			<li>
+				<a href="#input">Input</a>
+			</li>
+			<li>
+				<a href="#navigation">Navigation</a>
+			</li>
+			<li>
+				<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://mozilla.github.com/x-tag/" data-via="csuwldcat" data-hashtags="WebComponents">Tweet</a>
+			</li>
+		</ul>
 	</nav>
 </header>
 
-<div id="tags" class="max-width">
+<div id="tags" class="container max-width">
+	<h2 id="tag_line">Demos that put X-Tag in action.</h2>
 
 	<h3>
 		Structural Elements
@@ -78,11 +88,7 @@
 			<x-panel id="panel_demo" rel="demo/html/panel-content.html"></x-panel>
 			
 <h4>The Markup:</h4>		
-<pre>
-<code>
-<x-panel src="demo/html/panel-content.html"></x-panel>
-</code>
-</pre>
+<pre><code><x-panel src="demo/html/panel-content.html"></x-panel></code></pre>
 		</dd>
 		
 		<dt>Tab Box</dt>
@@ -134,9 +140,7 @@
 			</x-tabbox>
 			
 <h4>The Markup:</h4>
-<pre>
-<code>
-<x-tabbox>
+<pre><code><x-tabbox>
 	<x-tabs>
 		<x-tab>Tab 1</x-tab>
 		<x-tab>Tab 2</x-tab>
@@ -147,9 +151,7 @@
 		<x-tabpanel>Panel 2</x-tabpanel>
 		<x-tabpanel>Panel 3</x-tabpanel>
 	</x-tabpanels>
-</x-tabbox>
-</code>
-</pre>
+</x-tabbox></code></pre>
 	
 	<dt>Accordion</dt>
 	<dd id="accordion">
@@ -188,9 +190,7 @@
 			</div>
 		</x-accordion>
 <h4>The Markup:</h4>
-<pre>
-<code>
-<x-accordion>
+<pre><code><x-accordion>
 	<x-toggler selected="true">Toggler 1</x-toggler>
 	<div>Panel 1</div>
 	
@@ -199,9 +199,7 @@
 	
 	<x-toggler>Toggler 3</x-toggler>
 	<div>Panel 3</div>
-</x-accordion>
-</code>
-</pre>	
+</x-accordion></code></pre>	
 	</dd>
 
 		</dd>
@@ -229,17 +227,13 @@
 			</x-slidebox>
 			
 <h4>The Markup:</h4>
-<pre>
-<code>
-<x-slidebox>
+<pre><code><x-slidebox>
 	<x-slides>
 		<x-slide>Slide 1</x-slide>
 		<x-slide>Slide 2</x-slide>
 		<x-slide>Slide 3</x-slide>
 	</x-slides>
-</x-slidebox>
-</code>
-</pre>
+</x-slidebox></code></pre>
 		</dd>
 
 		<dt>Flip Box</dt>
@@ -261,16 +255,12 @@
 			</x-flipbox>
 			
 <h4>The Markup:</h4>
-<pre>
-<code>
-<x-flipbox>
+<pre><code><x-flipbox>
 	<x-card>
 		<div>Side 1</div>
 		<div>Side 2</div>
 	</x-card>
-</x-flipbox>
-</code>
-</pre>	
+</x-flipbox></code></pre>	
 		</dd>
 		
 		<dt>Modal<span feature="data-bound" title="This element has data request bindings"></span></dt>
@@ -285,11 +275,7 @@
 			</nav>
 			
 <h4>The Markup:</h4>
-<pre>
-<code>
-<x-modal> YOUR CONTENT HERE </x-modal>
-</code>
-</pre>	
+<pre><code><x-modal> YOUR CONTENT HERE </x-modal></code></pre>	
 		</dd>
 	</dl>
 	
@@ -308,11 +294,7 @@
 			<x-map id="map_demo" data-key="39d2b66f0d5d49dbb52a5b7ad87aea9b"></x-map>
 			
 <h4>The Markup:</h4>
-<pre>
-<code>
-<x-map data-key="Cloudmade/OpenStreetMaps-API-Key"></x-map>
-</code>
-</pre>	
+<pre><code><x-map data-key="Cloudmade/OpenStreetMaps-API-Key"></x-map></code></pre>	
 		</dd>
 	</dl>
 	
@@ -330,11 +312,7 @@
 			<x-autosuggest id="autosuggest_demo" data-padding="2" data-url="http://api.rottentomatoes.com/api/public/v1.0/movies.json?apikey=v695ukwehrcb5q8kwkrgjmbd&page_limit=10&page=1"></x-autosuggest>
 
 <h4>The Markup:</h4>
-<pre>
-<code>
-<x-autosuggest data-url="SOME-API-URL-HERE"></x-autosuggest>
-</code>
-</pre>	
+<pre><code><x-autosuggest data-url="SOME-API-URL-HERE"></x-autosuggest></code></pre>	
 		</dd>
 	</dl>
 	
@@ -366,11 +344,7 @@
 			</x-pager>
 			
 <h4>The Markup:</h4>
-<pre>
-<code>
-<x-pager data-pages="10" data-url="/posts?p={current-page}"></x-pager>
-</code>
-</pre>
+<pre><code><x-pager data-pages="10" data-url="/posts?p={current-page}"></x-pager></code></pre>
 		</dd>
 		
 		<dt>Action Bar</dt>
@@ -449,13 +423,12 @@
 
 <script type="text/javascript" src="demo/highlight/highlight.pack.js"></script>
 <script type="text/javascript">
-	
-	
-	
 	xtag.query(document.body, 'code').forEach(function(el){
-		var text = el.innerHTML;
-		el.innerHTML = '';
-		el.textContent = text;
+		if (el.parentNode.id != 'logo') {
+			var text = el.innerHTML;
+			el.innerHTML = '';
+			el.textContent = text;
+		}
 	});
 	
 	hljs.tabReplace = '    ';
@@ -626,5 +599,7 @@
 		}
 	});
 </script>
+
+<script id="twitter-wjs" type="text/javascript" src="http://platform.twitter.com/widgets.js"></script>
 
 </html>

--- a/demo/css/demo.css
+++ b/demo/css/demo.css
@@ -11,8 +11,32 @@ nav.actions {
 nav.actions button {
 	float: left;
 	margin: 4px 4px 4px 0;
-	padding-bottom: 1px;
+	padding: 6px 8px;
 	cursor: pointer;
+	border: 1px solid #ddd;
+	background: #eee;
+	border-radius: 5px;
+	-moz-border-radius: 5px;
+	-webkit-border-radius: 5px;
+	background: linear-gradient(top, #fafafa, #eee);
+	background: -o-linear-gradient(top, #fafafa, #eee);
+	background: -ms-linear-gradient(top, #fafafa, #eee);
+	background: -moz-linear-gradient(top, #fafafa, #eee);
+	background: -webkit-linear-gradient(top, #fafafa, #eee);
+}
+
+nav.actions button:active, x-pager a:active {
+	background: linear-gradient(top, #eee, #fafafa);
+	background: -o-linear-gradient(top, #eee, #fafafa);
+	background: -ms-linear-gradient(top, #eee, #fafafa);
+	background: -moz-linear-gradient(top, #eee, #fafafa);
+	background: -webkit-linear-gradient(top, #eee, #fafafa);
+}
+
+nav.actions code {
+	border: none;
+	padding: 0;
+	font-size: 100%;
 }
 
 #tags {
@@ -22,8 +46,8 @@ nav.actions button {
 
 span[feature] {
 	display: inline-block;
-    float: right;
-    padding: 11px 9px;
+	float: right;
+	padding: 11px 9px;
 	background: no-repeat center center;
 }
 
@@ -71,7 +95,8 @@ span[feature="data-bound"] {
 		}
 
 	#tabbox_demo.style x-tab {
-		padding: 0 4px 1px;
+		outline: none;
+		padding: 3px 10px;
 		border: 1px solid;
 		border-color: #cacaca #b0b0b0 #b0b0b0;
 		background: #fafafa;
@@ -89,10 +114,8 @@ span[feature="data-bound"] {
 	}
 
 	#tabbox_demo.style x-tab[selected="true"] {
-		padding-bottom: 2px;
 		color: #000;
 		border-bottom-width: 0;
-		background: linear-gradient(top, #fefefe, #E7EDF6);
 		background: -o-linear-gradient(top, #fefefe, #E7EDF6);
 		background: -ms-linear-gradient(top, #fefefe, #E7EDF6);
 		background: -moz-linear-gradient(top, #fefefe, #E7EDF6);
@@ -145,7 +168,7 @@ span[feature="data-bound"] {
 
 	#tabbox_demo.style x-tabpanels {
 		margin-top: -1px;
-		padding: 4px 6px;
+		padding: 10px 15px;
 		border: 1px solid;
 		border-color: #b0b0b0 #b0b0b0 #a0a0a0;
 		background: linear-gradient(top, #E7EDF6, #CFDBEC);
@@ -241,8 +264,9 @@ span[feature="data-bound"] {
 	}
 	
 	#accordion_demo.style x-toggler {
+		outline: none;
 		margin-top: 4px;
-		padding: 0 4px 2px;
+		padding: 4px 10px;
 		border: 1px solid;
 		border-color: #cacaca #afafaf #a0a0a0;
 		background: linear-gradient(top, #fafafa, #dadada);
@@ -269,6 +293,10 @@ span[feature="data-bound"] {
 		cursor: default;
 	}
 
+	#accordion_demo div {
+		padding: 5px 10px;
+	}
+
 /* MAP DEMO */
 
 	#map_demo {
@@ -282,6 +310,35 @@ span[feature="data-bound"] {
 		z-index: 1;
 	}
 
+	#autosuggest_demo input {
+		padding: 6px 8px;
+		border: 1px solid #ddd;
+		border-radius: 2px;
+		outline: none;
+		background: linear-gradient(top, #efefef, #fafafa);
+		background: -o-linear-gradient(top, #efefef, #fafafa);
+		background: -ms-linear-gradient(top, #efefef, #fafafa);
+		background: -moz-linear-gradient(top, #efefef, #fafafa);
+		background: -webkit-linear-gradient(top, #efefef, #fafafa);
+	}
+
+	#autosuggest_demo ul {
+		border-right: 1px solid #ddd;
+		border-left: 1px solid #ddd;
+		border-bottom: 1px solid #ddd;
+	}
+
+	#autosuggest_demo li {
+		padding: 5px 10px;
+		border-bottom: 1px dotted #ddd;
+		outline: none;
+	}
+
+	#autosuggest_demo li[selected] {
+		background-color: #5b84c8;
+		color: #fff;
+	}
+
 /* FLIPBOX DEMO */
 
 	#flipbox_demo{
@@ -293,3 +350,37 @@ span[feature="data-bound"] {
 		-moz-perspective: 1000px;
 		-webkit-perspective: 1000px;
 	}
+
+/* PAGER DEMO */
+
+	x-pager {
+		margin-bottom: 10px;
+	}
+
+	x-pager a {
+		padding: 4px 7px;
+		border: 1px solid #ddd;
+		border-radius: 5px;
+		-webkit-border-radius: 5px;
+		-moz-border-radius: 5px;
+		background: linear-gradient(top, #fafafa, #eee);
+		background: -o-linear-gradient(top, #fafafa, #eee);
+		background: -ms-linear-gradient(top, #fafafa, #eee);
+		background: -moz-linear-gradient(top, #fafafa, #eee);
+		background: -webkit-linear-gradient(top, #fafafa, #eee);
+	}
+
+	x-pager a[selected="true"] {
+		color: #333;
+	}
+
+	x-pager a:hover {
+		border-bottom: 1px solid #ddd;
+	}
+
+/* NAVIGATION DEMO */
+
+	x-action label {
+		padding-right: 10px;
+	}
+

--- a/demo/css/global.css
+++ b/demo/css/global.css
@@ -1,15 +1,11 @@
-
-body
-{
-	padding-top: 80px;
-	font-family: Segoe UI, Trebuchet MS, Helvetica, Arial;
-	font-size: 14px;
+body {
+	font: 14px/1.7 "Lucida Grande", "Lucida Sans Unicode", "Lucida Sans", Helvetica, Arial, Sans-Serif;
 	background: url(../images/spatter.jpg);
 }
 
-h1, h2, h3, h4 , dt, .font {
+h1, h2, h3, h4, dt {
 	position: relative;
-	font-family: 'Days One', san-serif;
+	font-family: Georgia, Cambria, "Times New Roman", Times, Serif;
 	font-weight: normal;
 }
 
@@ -22,46 +18,69 @@ h2 {
 }
 
 h3 {
-	float: left;
-	margin-bottom: 10px;
-	padding: 4px 9px;
+	position: absolute;
+	left: 0;
+	display: inline;
+	padding: 8px 9px 4px 9px;
 	font-size: 135%;
 	color: #fff;
 	text-decoration: none;
 	background: url("../images/header-bk.png");
-	border-radius: 5px;
+	border-top-left-radius: 5px;
+	border-bottom-right-radius: 5px;
 	border: 1px solid #226AB3;
 	border-bottom: 1px solid #003474;
 	box-shadow: 0px 1px 3px -2px #000;
 	-ms-box-shadow: 0px 1px 3px -2px #000;
 	-moz-box-shadow: 0px 1px 3px -2px #000;
 	-webkit-box-shadow: 0px 1px 3px -2px #000;
+	letter-spacing: 1px;
+	text-shadow: 1px 1px #333;
+}
+
+h3, #tag_line, #logo {
+	font-family: "Josefin Sans", "Trebuchet MS", Helvetica, Arial, Sans-Serif;
+	text-transform: uppercase;
 }
 
 p {
 	margin: 0 0 10px;
 }
 
+a {
+	color: #3366bb;
+	text-decoration: none;
+	border-bottom: 1px solid;
+}
+
+a:hover {
+	border-bottom: none;
+}
+
 code {
-	padding: 0 2px 1px;
+	font: 13px/1.7 Monaco, "Courier New", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", monospace;
+	padding: 2px 4px;
 	border: 1px solid;
 	border-color: #dfdfdf #dadada #d0d0d0;
-	font-size: 80%;
 	border-radius: 3px;
 	-ms-border-radius: 3px;
 	-moz-border-radius: 3px;
 	-webkit-border-radius: 3px;
 }
 
+pre {
+	margin: 0 -15px;
+}
+
 pre code {
-	padding: 0 1em 1em;
+	padding: 10px 20px;
 	background: #fafafa;
 	border: 1px solid #eee;
 }
 
 p code {
 	position: relative;
-    top: -1px;
+	top: -1px;
 	margin: 0 2px;
 	background: linear-gradient(top, #fafafa, #efefef);
 	background: -ms-linear-gradient(top, #fafafa, #efefef);
@@ -70,46 +89,27 @@ p code {
 }
 
 h4 {
-	margin: 14px 0 4px;
+	margin: 14px 0 10px;
 }
 
 h4 code {
-	padding: 0 3px;
 	background: url("../images/header-bk.png") left -10px;
-	border: 1px solid #226AB3;
-    border-bottom: 1px solid #003474;
-    border-radius: 5px;
+	border: 1px solid #335c8f;
+	border-radius: 5px;
 	color: #fff;
 	font-size: 90%;
 }
 
 h4 span {
 	padding-left: 6px;
-	font-family: Segoe UI, Trebuchet MS, Helvetica, Arial;
-	font-style: italic;
+	font-family: "Lucida Grande", "Lucida Sans Unicode", "Lucida Sans", Helvetica, Arial, Sans-Serif;
+	color: #999;
+	text-transform: lowercase;
 }
 
-button code {
-	position: relative;
-    top: -1px;
-	background: #fff;
-}
-
-body > header {
-	position: fixed;
-	top: 0;
-	left: 0;
-	height: 46px;
-	width: 100%;
-	border-top: 1px solid #003576;
-	border-bottom: 2px solid #003474;
-	background: url(../images/header-bk.png);
-	box-shadow: 0 1px 4px -2px #000;
-	-ms-box-shadow: 0 1px 4px -2px #000;
-	-moz-box-shadow: 0 1px 4px -2px #000;
-	-webkit-box-shadow: 0 1px 4px -2px #000;
-	opacity: 0.95;
-	z-index: 2;
+header.container {
+	margin-bottom: 20px;
+	padding-top: 10px;
 }
 
 body > header > iframe, body > header > a {
@@ -124,108 +124,73 @@ body > header > iframe, body > header > a {
 }
 
 .font {
-	color: #555;
-	font-size: 90%;
+	font-style: italic;
 }
 
 #logo {
 	float: left;
-	margin-left: 8px;
-	font-family: 'Righteous';
-	font-size: 275%;
-	color: #F3F3F3;
-	text-shadow: 0 1px 0 #fff, 0 -1px 0 rgba(0,52,116, 0.7);
+	font-size: 170%;
+	padding: 5px 0;
+	color: #000;
+	font-weight: bold;
+	text-shadow: 0 1px 0 #fff, 0 -1px 0 rgba(0, 0, 0, 0.3);
 }
 
-#logo span {
-	position: relative;
-    top: -6px;
-    font-size: 90%;
-    margin: 0 2px;
+#logo code {
+	border: none;
+	font-size: 80%;
 }
 
 #global_menu {
-	position: relative;
+	overflow: hidden;
+}
+
+#global_menu ul {
 	float: right;
-	padding: 16px 20px 22px 20px;
 }
 
-#global_menu > a {
+#global_menu li {
+	float: left;
+	display: inline;
+}
+
+#global_menu a {
 	display: block;
-	margin-left: 18px;
-	color: #fff;
-	font-size: 23px;
-	font-weight: bold;
+	height: 50px;
+	line-height: 50px;
 	text-decoration: none;
-	line-height: 0;
+	padding: 0 10px;
+	border-bottom: 0;
+	text-shadow: 1px 1px #eee;
 }
 
-#global_menu > a:first-child {
-	margin-left: 0;
+#global_menu a:hover {
+	color: #222;
+	background-color: rgba(255, 255, 255, 0.1);
 }
 
-#global_menu > a div {
-    position: relative;
+.twitter-share-button {
+	margin: 16px 0 0 10px;
 }
 
-#global_menu > a div:last-child {
-    top: 8px;
-}
-
-#global_nav {
-	display: none;
-	position: absolute;
-	top: 100%;
-	right: 20px;
-	width: 175px;
-	background: #fff;
-	border: 1px solid;
-	border-color: #0E56A9;
-	border-radius: 3px;
-	-ms-border-radius: 3px;
-	-moz-border-radius: 3px;
-	-webkit-border-radius: 3px;
-	box-shadow: 0 1px 7px -2px #000;
-	-ms-box-shadow: 0 1px 7px -2px #000;
-	-moz-box-shadow: 0 1px 7px -2px #000;
-	-webkit-box-shadow: 0 1px 7px -2px #000;
-}
-
-#global_nav.small-nav {
-	width: 90px;
-}
-
-#global_nav a {
-	display: block;
-	padding: 0 8px 6px;
-	text-decoration: none;
-	color: #466EA6;
-	font-weight: bold;
-}
-
-#global_nav a:hover {
-	text-decoration: underline;
-}
-
-#global_menu:hover #global_nav {
-	display: block;
-}
-
-
-.max-width {
+.container {
 	width: 90%;
 	min-width: 300px;
-	max-width: 600px;
+	max-width: 700px;
 	margin: 0 auto;
 	overflow: hidden;
 }
 
+.max-width {
+	position: relative;
+}
+
 div.max-width > dl {
 	margin-bottom: 40px;
-	padding: 12px 10px;
+	padding: 50px 25px 20px 25px;
 	background: #fff;
 	border: 1px solid;
-	border-color: #bbb #ccc #ddd;
+	border-color: #bbb #ccc;
 	border-radius: 4px;
 	-moz-border-radius: 4px;
 	-webkit-border-radius: 4px;
@@ -234,29 +199,25 @@ div.max-width > dl {
 
 div.max-width > dl dt {
 	font-size: 120%;
-	background: linear-gradient(top, #F3F3F3, #E6E6E6);
-	background: -ms-linear-gradient(top, #F3F3F3, #E6E6E6);
-	background: -moz-linear-gradient(top, #F3F3F3, #E6E6E6);
-	background: -webkit-linear-gradient(top, #F3F3F3, #E6E6E6);
-	border: 1px solid;
-	border-color: #E6E6E6 #dadada #d0d0d0;
-	margin-bottom: 8px;
-	padding: 2px 6px;
+	background-color: #e9e9e9;
+	border-top: 1px solid #ddd;
+	border-bottom: 1px solid #ddd;
+	padding: 10px 25px;
 	text-shadow: 0 1px 0 #fff;
-	border-radius: 3px;
-	-moz-border-radius: 3px;
-	-webkit-border-radius: 3px;
+	margin: 0 -25px 8px -25px;
 }
 
 div.max-width > dl dd {
 	margin: 0 10px 20px;
 }
 
-div.max-width > dl dd ol {
+div.max-width > dl ol {
 	margin: 0 15px 10px;
 	padding: 6px 6px 6px 26px;
-	background: #fafafa;
-	border: 1px solid #eee;
+}
+
+div.max-width > dl li {
+	padding: 1px 0;
 }
 
 div.max-width > dl > dd:last-child p:last-child {
@@ -265,27 +226,11 @@ div.max-width > dl > dd:last-child p:last-child {
 
 #tag_line {
 	position: relative;
-	margin-bottom: 50px;
-    padding-bottom: 20px;
-	color: #ccc;
-    text-shadow: 0 1px 0 #fff, 0 -1px 0 rgba(0, 0, 0, 0.3);
+	margin-bottom: 30px;
+	color: #444;
+	text-shadow: 0 1px 0 #fff, 0 -1px 0 rgba(0, 0, 0, 0.3);
 	text-align: center;
-}
-
-#tag_line:before, #tag_line:after {
-	display: block;
-	content: " ";
-	position: absolute;
-	top: 100%;
-	left: 50%;
-	width: 66px;
-	margin-left: -33px;
-	border-bottom: 8px dotted #fff;
-}
-
-#tag_line:after {
-	margin-top: -1px;
-	border-bottom-color: #ddd;
+	letter-spacing: 1px;
 }
 
 #browser_logos {
@@ -295,12 +240,12 @@ div.max-width > dl > dd:last-child p:last-child {
 }
 
 #browser_logos a {
-    display: table-cell;
+	display: table-cell;
 	width: 20%;
-    font-weight: bold;
-    text-align: center;
-    text-decoration: none;
-    color: #466EA6;
+	font-weight: bold;
+	text-align: center;
+	color: #466EA6;
+	border: none;
 }
 
 #browser_logos a img {
@@ -312,13 +257,14 @@ div.max-width > dl > dd:last-child p:last-child {
 
 #browser_logos a span {
 	display: block;
-    font-size: 10px;
+	font-size: 10px;
 	color: #999;
 }
 
 #doc_list dd {
 	margin-bottom: 12px;
-	border-bottom: 1px dashed #bbb;
+	padding-bottom: 12px;
+	border-bottom: 1px dotted #bbb;
 }
 
 #doc_list dd:last-child {

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 		<title>X-Tag - a cross-browser web components library</title>
 		<link href="demo/images/shortcut.png" rel="shortcut icon" type="image/x-icon" />
 		<link rel="stylesheet" type="text/css" href="demo/css/reset.css" />
-		<link href='http://fonts.googleapis.com/css?family=Days+One|Righteous' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Josefin+Sans:600" rel='stylesheet' type='text/css'>
 		<link rel="stylesheet" type="text/css" href="demo/highlight/styles/vs.css" />
 		<link rel="stylesheet" type="text/css" href="demo/css/global.css"/>
 		
@@ -14,28 +14,33 @@
 
 <body>
 
-<header>
-	<h1 id="logo">&lt;<span>x</span>&gt;</h1>
+<header class="container">
+	<h1 id="logo">X-Tag <code>&lt;X&gt;</code></h1>
 	
 	<nav id="global_menu">
-		<a href="#menu">
-			<div>&#9552;</div><br /><div>&#9552;</div>
-			<nav id="global_nav" class="small-nav">
-				<a href="#intro">Intro</a>
-				<a href="#docs">Docs</a>
+		<ul>
+			<li>
+				<a href="#intro">Introduction</a>
+			</li>
+			<li>
+				<a href="#docs">Documentation</a>
+			</li>
+			<li>
 				<a href="#examples">Examples</a>
-			</nav>
-		</a>
+			</li>
+			<li>
+				<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://mozilla.github.com/x-tag/" data-via="csuwldcat" data-hashtags="WebComponents">Tweet</a>
+			</li>
+		</ul>
 	</nav>
 	
-	<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://mozilla.github.com/x-tag/" data-via="csuwldcat" data-hashtags="WebComponents">Tweet</a>
 </header>
 
-<div class="max-width">
+<div class="container max-width">
 	<h2 id="tag_line">Custom HTML elements for modern browsers.</h2>
 	
 	<h3>
-		Intro
+		Introduction
 		<span id="intro" class="anchor-id"></span>
 	</h3>
 	<dl>
@@ -83,9 +88,7 @@
 				the element is injected into the DOM. Here's an example with some comments for a bit more clarity:
 			</p>
 			
-<pre>
-<code>
-xtag.register('accordion', {
+<pre><code>xtag.register('accordion', {
 	onCreate: function(){
 		// fired once at the time a component 
 		// is initially created or parsed
@@ -115,9 +118,7 @@ xtag.register('accordion', {
 			// activate the previous toggler
 		}
 	}
-});
-</code>
-</pre>
+});</code></pre>
 		</dd>
 		
 		<dt>Browser Support</dt>
@@ -161,7 +162,7 @@ xtag.register('accordion', {
 	</dl>
 	
 	<h3>
-		Docs
+		Documentation
 		<span id="docs" class="anchor-id"></span>
 	</h3>
 	<dl id="doc_list">
@@ -174,13 +175,9 @@ xtag.register('accordion', {
 				in the W3 Web Components draft.
 			</p>
 			
-<pre>
-<code>
-xtag.register('superinput', {
+<pre><code>xtag.register('superinput', {
 	content: '<input type="text" />'
-});
-</code>
-</pre>
+});</code></pre>
 
 		</dd>
 		
@@ -191,16 +188,12 @@ xtag.register('superinput', {
 				<code>document.createElement</code>, an onCreate function is called 
 				allowing you to modify the element before any other code is applied to it.
 			</p>
-<pre>
-<code>
-xtag.register('superinput', {
+<pre><code>xtag.register('superinput', {
 	onCreate: function(){
 		// superinputs begin life knowing they're super.
 		this.value = 'super';
 	}
-});
-</code>
-</pre>
+});</code></pre>
 
 		</dd>	
 		
@@ -213,16 +206,12 @@ xtag.register('superinput', {
 				component accordingly.
 			</p>
 			
-<pre>
-<code>
-xtag.register('superinput', {
+<pre><code>xtag.register('superinput', {
 	onInsert: function(){
 		// superinputs announce their arrival in the DOM like a boss!
 		alert("Yeah, that's right, superinput comin' thro'!");
 	}
-});
-</code>
-</pre>
+});</code></pre>
 
 		</dd>
 		
@@ -235,18 +224,14 @@ xtag.register('superinput', {
 				getter would have the oppertunity to fetch that value from anywhere 
 				you'd like and even modify it before returning.
 			</p>
-<pre>
-<code>
-xtag.register('superinput', {
+<pre><code>xtag.register('superinput', {
 	getters: {
 		value: function(){
 			// everything superinputs do has a little super mixed in ;)
 			return this.value + '  is super';
 		}
 	}
-});
-</code>
-</pre>
+});</code></pre>
 
 		</dd>
 		
@@ -258,9 +243,7 @@ xtag.register('superinput', {
 				your setter would be called with the provided string value giving you a chance to
 				manipulate the string or change properties on the element.
 			</p>
-<pre>
-<code>
-xtag.register('superinput', {
+<pre><code>xtag.register('superinput', {
 	setters: {
 		value: function(value){
 			// boy, these superinputs sure are loud little buggers.
@@ -268,9 +251,7 @@ xtag.register('superinput', {
 			this.value = value;
 		}
 	}
-});
-</code>
-</pre>
+});</code></pre>
 
 		</dd>
 		
@@ -281,17 +262,13 @@ xtag.register('superinput', {
 				Pseudo events like delegation are supported, additional pseudos can be added to 
 				the <code>pseudos</code> object on the global <code>xtag</code> variable.
 			</p>
-<pre>
-<code>
-xtag.register('superinput', {
+<pre><code>xtag.register('superinput', {
 	events: {
 		focus: function(){
 			// what should superinputs do when they're in the spotlight?
 		}
 	}
-});
-</code>
-</pre>			
+});</code></pre>			
 			
 		</dd>
 		
@@ -304,13 +281,9 @@ xtag.register('superinput', {
 				you can add your own mixins there too!
 			</p>
 
-<pre>
-<code>
-xtag.register('superinput', {
+<pre><code>xtag.register('superinput', {
 	mixins: ['superdefaults']
-});
-</code>
-</pre>
+});</code></pre>
 		</dd>
 	</dl>
 


### PR DESCRIPTION
The home and demo pages could have clearer typography, a more intuitive navigation, more whitespace in the main content area for readability, and, in the case of the demo page, more styling for some of the elements. This pull request addresses these concerns. I've included two screenshots of my changes—one for the home page and one for the demo page—below:
## Home Page

![Index page](https://dl.dropbox.com/u/5642420/xtag-index.png)
## Demo Page

![Index page](https://dl.dropbox.com/u/5642420/xtag-demo.png)
