### PR TITLE
Call AMD define so AMD-based projects can get a local reference to xtag....

### DIFF
--- a/x-tag.js
+++ b/x-tag.js
@@ -339,6 +339,10 @@
 		}
 	};
 	
+	if (typeof define === 'function' && define.amd) {
+		define(xtag);
+	}
+	
 	var styles = document.createElement('style'),
 		nodeInserted = function(event){
 			if (event.animationName == 'XTagNodeInserted'){


### PR DESCRIPTION
... Still preserves the global xtag in case the project is mixed with non-AMD code that uses xtag.

Related to mozilla/x-tag#48
