### PR TITLE
Make x-tag work in strict mode.

### DIFF
--- a/x-tag.js
+++ b/x-tag.js
@@ -107,7 +107,7 @@
     click: 'touchend'
   };
   
-  xtag = {
+  var xtag = {
     tags: {},
     tagList: [],
     callbacks: {},
@@ -697,6 +697,10 @@
     }, false);
   }
   
-  if (typeof define == 'function' && define.amd) define(xtag);
+  if (typeof define == 'function' && define.amd) {
+      define(xtag);
+  } else {
+      win.xtag = xtag;
+  }
   
 })();


### PR DESCRIPTION
The module loader we are using here at IMVU forces everything to use strict mode, and we ran into a tiny problem making it work with your library.  This little change seems to do the trick.

Thanks!
